### PR TITLE
Configuration, Dependency Injection services, and some usabilities tweaks

### DIFF
--- a/Adapter/ArrayAdapter.php
+++ b/Adapter/ArrayAdapter.php
@@ -20,19 +20,39 @@ use MakerLabs\PagerBundle\Adapter\PagerAdapterInterface;
  */
 class ArrayAdapter implements PagerAdapterInterface, \Iterator, \ArrayAccess, \Countable
 {
+    /**
+     * @var array
+     */
     protected $array;
-    protected $cursor = 0;
-    protected $totalItems = null;
 
-    public function __construct(array $array)
+    /**
+     * @var int
+     */
+    protected $cursor = 0;
+
+    /**
+     * @var int
+     */
+    protected $totalItems;
+
+    public function __construct(array $array = null)
     {
-        $this->array = $array;
+        if(null !== $array) {
+            $this->setArray($array);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    function countResults($offset = null, $limit = null) {
+        return count(array_slice($this->array, $offset, $limit));
     }
 
     public function getTotalResults()
     {
         if (null === $this->totalItems) {
-            $this->totalItems = count($this->array);
+            $this->totalItems = $this->countResults();
         }
 
         return $this->totalItems;
@@ -98,5 +118,24 @@ class ArrayAdapter implements PagerAdapterInterface, \Iterator, \ArrayAccess, \C
     public function count()
     {
         return $this->getTotalResults();
+    }
+
+    /**
+     * Set the array
+     * @param $array
+     * @return ArrayAdapter Provides a fluent interface
+     */
+    public function setArray($array) {
+        $this->array = $array;
+        $this->totalItems = null;
+        return $this;
+    }
+
+    /**
+     * Get the array
+     * @return array
+     */
+    public function getArray() {
+        return $this->array;
     }
 }

--- a/Adapter/PagerAdapterInterface.php
+++ b/Adapter/PagerAdapterInterface.php
@@ -31,4 +31,9 @@ interface PagerAdapterInterface
      * @return integer
      */
     function getTotalResults();
+
+    /**
+     * Returns the total number of results for the current offset & limit
+     */
+    function countResults($offset = null, $limit = null);
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -20,10 +20,13 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('maker_labs_pager');
 
-        // Here you should define the parameters that are allowed to
-        // configure your bundle. See the documentation linked above for
-        // more information on that topic.
-
+        $rootNode
+            ->children()
+                ->scalarNode('limit')->defaultValue('20')->end()
+                ->scalarNode('max_pages')->defaultValue('10')->end()
+                ->scalarNode('template')->defaultNull()->end()
+            ->end()
+            ;
         return $treeBuilder;
     }
 }

--- a/DependencyInjection/MakerLabsPagerExtension.php
+++ b/DependencyInjection/MakerLabsPagerExtension.php
@@ -6,6 +6,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * This is the class that loads and manages your bundle configuration
@@ -24,5 +25,28 @@ class MakerLabsPagerExtension extends Extension
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');
+        $loader->load('adapters.xml');
+
+        if($config['limit']) {
+            $container->setParameter('maker_labs_pager.pager.limit', $config['limit']);
+        }
+        if($config['max_pages']) {
+            $container->setParameter('maker_labs_pager.pager.max_pages', $config['max_pages']);
+        }
+        if($config['template']) {
+            $container->setParameter('maker_labs_pager.pager.template', $config['template']);
+        }
+
+        $pagerDef = $container->getDefinition('maker_labs_pager.pager');
+        $pagerDef->replaceArgument(0, null);
+
+        // Add concrete pagers based on the same defintion (and defaults) as the main pager class
+        $doctrineOrmPagerDef = clone $pagerDef;
+        $doctrineOrmPagerDef->replaceArgument(0, new Reference('maker_labs_pager.adapter.doctrine_orm'));
+        $container->setDefinition('maker_labs_pager.doctrine_orm_pager', $doctrineOrmPagerDef);
+
+        $arrayPagerDef = clone $pagerDef;
+        $arrayPagerDef->replaceArgument(0, new Reference('maker_labs_pager.adapter.array'));
+        $container->setDefinition('maker_labs_pager.array_pager', $arrayPagerDef);
     }
 }

--- a/Resources/config/adapters.xml
+++ b/Resources/config/adapters.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="maker_labs_pager.adapter.doctrine_orm.class">MakerLabs\PagerBundle\Adapter\DoctrineOrmAdapter</parameter>
+        <parameter key="maker_labs_pager.adapter.array.class">MakerLabs\PagerBundle\Adapter\ArrayAdapter</parameter>
+    </parameters>
+
+    <services>
+
+        <service id="maker_labs_pager.adapter.doctrine_orm" class="%maker_labs_pager.adapter.doctrine_orm.class%" scope="prototype" />
+
+        <service id="maker_labs_pager.adapter.array" class="%maker_labs_pager.adapter.array.class%" scope="prototype" />
+    </services>
+
+</container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -5,19 +5,33 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
+        <!-- provided by config -->
+        <parameter key="maker_labs_pager.pager.limit" />
+        <parameter key="maker_labs_pager.pager.max_pages" />
+        <parameter key="maker_labs_pager.pager.template" />
+        <!-- hardcoded -->
         <parameter key="makerlabs.templating.helper.pager.class">MakerLabs\PagerBundle\Templating\Helper\PagerHelper</parameter>
         <parameter key="makerlabs.twig.extension.pager.class">MakerLabs\PagerBundle\Twig\Extension\PagerExtension</parameter>
+        <parameter key="maker_labs_pager.pager.class">MakerLabs\PagerBundle\Pager</parameter>
     </parameters>
 
     <services>
         <service id="makerlabs.twig.extension.pager" class="%makerlabs.twig.extension.pager.class%">
-            <argument type="service" id="router" />
+            <argument type="service" id="service_container" />
             <tag name="twig.extension" alias="pager" />
-        </service>        
+        </service>
         <service id="makerlabs.templating.helper.pager" class="%makerlabs.templating.helper.pager.class%">
-            <tag name="templating.helper" alias="pager" />
-            <argument type="service" id="templating.engine.php" />
+            <argument type="service" id="templating" />
             <argument type="service" id="router" />
+            <argument type="string">%maker_labs_pager.pager.template%</argument>
+            <tag name="templating.helper" alias="pager" />
+        </service>
+        <service id="maker_labs_pager.pager" class="%maker_labs_pager.pager.class%" scope="prototype">
+            <argument />
+            <argument type="collection">
+                <argument key="limit">%maker_labs_pager.pager.limit%</argument>
+                <argument key="max_pages">%maker_labs_pager.pager.max_pages%</argument>
+            </argument>
         </service>
     </services>
 

--- a/Templating/Helper/PagerHelper.php
+++ b/Templating/Helper/PagerHelper.php
@@ -27,11 +27,11 @@ class PagerHelper extends Helper
      * @var EngineInterface
      */
     protected $engine;
+
     /**
-     *
-     * @var RouterInterface
+     * @var string
      */
-    protected $router;
+    protected $template;
 
     /**
      * Constructor
@@ -39,8 +39,10 @@ class PagerHelper extends Helper
      * @param EngineInterface $engine The template engine service
      * @param RouterInterface $router The router service
      */
-    public function __construct(EngineInterface $engine, RouterInterface $router)
+    public function __construct(EngineInterface $engine, RouterInterface $router, $template = null)
     {
+        $this->template = $template ?: 'MakerLabsPagerBundle:Pager:paginate.html.php';
+
         $this->engine = $engine;
 
         $this->router = $router;
@@ -48,15 +50,17 @@ class PagerHelper extends Helper
 
     /**
      * Renders the HTML for a given pager
-     * 
+     *
      * @param Pager $pager A Pager instance
      * @param string $route The route name
      * @param array $parameters Additional route parameters
      * @param string $template The template name
-     * @return string The html markup 
+     * @return string The html markup
      */
-    public function paginate(Pager $pager, $route, array $parameters = array(), $template = 'MakerLabsPagerBundle:Pager:paginate.html.php')
+    public function paginate(Pager $pager, $route, array $parameters = array(), $template = null)
     {
+        $template = $template ?: $this->template;
+
         return $this->engine->render($template, array('pager' => $pager, 'route' => $route, 'parameters' => $parameters));
     }
 

--- a/Twig/Extension/PagerExtension.php
+++ b/Twig/Extension/PagerExtension.php
@@ -14,6 +14,7 @@ namespace MakerLabs\PagerBundle\Twig\Extension;
 use MakerLabs\PagerBundle\Pager;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use MakerLabs\PagerBundle\Templating\Helper\PagerHelper;
 
 /**
  * PagerExtension extends Twig with pagination capabilities.
@@ -22,25 +23,13 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class PagerExtension extends \Twig_Extension
 {
-    /**
-     *
-     * @var RouterInterface
-     */
-    protected $router;
-    /**
-     *
-     * @var \Twig_Environment
-     */
-    protected $environment;
+    protected $container;
 
-    public function __construct(RouterInterface $router)
-    {
-        $this->router = $router;
-    }
-
-    public function initRuntime(\Twig_Environment $environment)
-    {
-        $this->environment = $environment;
+    /**
+     * @param ContainerInterface $container
+     */
+    public function __construct(ContainerInterface $container) {
+        $this->container = $container;
     }
 
     public function getFunctions()
@@ -51,22 +40,25 @@ class PagerExtension extends \Twig_Extension
         );
     }
 
-    public function paginate(Pager $pager, $route, array $parameters = array(), $template = 'MakerLabsPagerBundle:Pager:paginate.html.twig')
+    public function paginate(Pager $pager, $route, array $parameters = array(), $template = null)
     {
-        return $this->environment->render($template, array('pager' => $pager, 'route' => $route, 'parameters' => $parameters));
+        $template = $template ?: $this->container->getParameter('maker_labs_pager.pager.template') ?: 'MakerLabsPagerBundle:Pager:paginate.html.php';
+
+        return $this->container->get('makerlabs.templating.helper.pager')->paginate(
+            $pager,
+            $route,
+            $parameters,
+            $template
+        );
     }
 
     public function path($route, $page, array $parameters = array())
     {
-        if (isset($parameters['_page'])) {
-            $parameters[$parameters['_page']] = $page;
-
-            unset($parameters['_page']);
-        } else {
-            $parameters['page'] = $page;
-        }
-
-        return $this->router->generate($route, $parameters);
+        return $this->container->get('makerlabs.templating.helper.pager')->path(
+            $route,
+            $page,
+            $parameters
+        );
     }
 
     public function getName()


### PR DESCRIPTION
A significant overhaul of the pager bundle to facilitate using the pager via DI, as well as some usability improvements. All changes and new features should be BC compatible.
#### Adapter/PagerAdapterInterface:
- Added a `countResults()` method to the interface which returns the the number of results for an optionally provided offset and limit. This method now powers the `getTotalResults()` methods in both concrete implementations
#### Adapter/DoctrineOrmAdapter:
- Removed the redundant default value of null ( '= null') from the totalItems property.
- Renamed the `$query` property to `$queryBuilder` for clarity.
- Made the $queryBuilder (formerly query) constructor argument optional and added new `set/getQueryBuilder()` methods (DI Improvements)
- Made the adapter implement `\Countable` via `count()` method which returns totalResults
- Added optional offset and limit parameters to `getCountQuery()`
- Implemented `countResults()` to call `getCountQuery()` and cache results per `$offset` and `$limit` arguments.
- Changed `getTotalResults() to use the new`countResults()` method
- Added `get/setHydrationMode()` (DI Improvements)
#### Adapter/ArrayAdapter
- Removed the redundant default value of null ( '= null') from the totalItems property.
- Made the array constructor argument optional and added new `set/getArray()` methods (DI Improvements)
- Implemented `countResults()`
- Changed `getTotalResults()` to use the new `countResults()` method
#### Pager:
- Implemented `\Countable` and `\IteratorAggregate` to provide simpler pager usage:
  - `count($pager)` / `{% results|length %}` - Returns the number of results in the current page
  - `foreach($pager as $result)` / `{% for result in results %}` -- Iterates through the items in the current page of the pager
- Made the `$adapter` constructor argument optional and added new `set/getAdapter()` methods (DI Improvements)
- Fixed whitespacing around `$maxPages` property
- Added `getPageCount()` method. I would recommend a check on this method be the preferred way to check if results should show the paginator (`isPaginable()` is an unusual name and not immediately clear what it's checking):
  `{% if results.getPageCount() > 1  %}  {{ paginate(result, …) }} {% endif %}`
- Moved min-page handling from `setPage($page)` to `getPage()` and removed the call to `setPage(...)` inside `setLimit(…)` to allow for DI usage (setting the limit on instantiation was causing a call to `setPage()` and the `getLastPage()` call within was triggering an error when the adapter didn't yet have a queryBuilder).
- Changed all calls to `$this->page` to `$this->getPage()` to support the later-in-life min-page handling mentioned above.
#### Resources/config/adapters.xml
- Added DI definitions for both adapters: `maker_labs_pager.adapter.doctrine_orm`, `makers_labs_pager.adapter.array`
#### Resources/config/services.xml
- Added DI definition for `maker_labs_pager.pager` with a null adapter parameter and defaults for limit and max_pages as provided by new configuration options (see below)
- Reconfigured service definition for `makerlabs.twig.extension.pager` (see below)
- Added template config  parameter as argument to `makerlabs.templating.helper.pager` definition.
- Changed tempting argument for `makerlabs.templating.helper.pager` to be the default templating engine, instead of the php-only engine.
- **_NOTE:**_ All new service terms use the more-properly normalized 'maker_labs_pager' rather than the previous 'makerlabs_pager' prefix (which was left in-place wherever it was already used). This better matches the Symfony style of bundle name inflection.
#### DependencyInjection/Configuration
- Added configuration options under the maker_labs_pager root node: limit, max_pages, and template (DI Improvements). All options are optional with defaults that match the previously class-hardcoded defaults.
#### DependencyInjection/MakerLabsPagerExtension
- Added configuration handling
- Dynamically clones the `maker_labs_pager.pager` service into 2 adapter-specific services (with the same configuration directives as the generic service): `maker_labs_pager.doctrine_orm_pager` and `maker_labs_pager.array_pager`.
#### Twig/Extension/PagerExtension
- Now proxying calls to `Templating/Helper/PagerHelper` to reduce code duplication.
- Passes through the default template as defined in configuration, or if omitted, `MakerLabsPagerBundle:Pager:pagination.html.twig`
#### Templating/Helper/PagerHelper
- Accepts a default template from configuration, or a call-time template (which might be the PagerExtension twig template), or if neither, uses `MakerLabsPagerBundle:Pager:pagination.html.php`.
