### PR TITLE
Updated return a range of pages

### DIFF
--- a/Pager.php
+++ b/Pager.php
@@ -213,11 +213,13 @@ class Pager
     {
         $pages = $this->getMaxPages();
         
-        $tmp = $this->page - floor($pages / 2);
+        $tmp = $this->page - floor($pages / 2) + 1;
 
-        $begin = $tmp > $this->getFirstPage() ? $tmp : $this->getFirstPage();
+        $start = $tmp > $this->getFirstPage() ? $tmp : $this->getFirstPage();
 
-        $end = min($begin + $pages - 1, $this->getLastPage());
+        $end = min($start + $pages - 1, $this->getLastPage());
+        
+        $begin = ($end - $pages + 1) > $this->getFirstPage() ? $end - $pages + 1 : $this->getFirstPage();
 
         return range($begin, $end, 1);
     }


### PR DESCRIPTION
If page = 20 and maximum number of displayed pages 10, current 18, then:

Old implementation:
tmp = 18 - 5 = 13
begin = 13
end = 20
Total will be returned only 7 pages.

In the new implementation:
tmp = 18 - 5 + 1 = 14 (+1 for more shows to the next page)
start = 14
end = 20
begin = 11
Total will be returned only 10 pages, because they exist, and do not reduce the navigation.
