### PR TITLE
Fix twig deprecated function

### DIFF
--- a/Twig/Extension/PagerExtension.php
+++ b/Twig/Extension/PagerExtension.php
@@ -46,8 +46,8 @@ class PagerExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'paginate' => new \Twig_Function_Method($this, 'paginate', array('is_safe' => array('html'))),
-            'paginate_path' => new \Twig_Function_Method($this, 'path', array('is_safe' => array('html'))),
+            new \Twig_SimpleFunction('paginate', [$this, 'paginate'], array('is_safe' => array('html'))),
+            new \Twig_SimpleFunction('paginate_path', [$this, 'path'], array('is_safe' => array('html'))),
         );
     }
 


### PR DESCRIPTION
I have replaced from Twig_Function_Method to Twig_SimpleFunction.
Because I got this error.
"The Twig_Function_Method class is deprecated since version 1.12 and will be removed in 2.0. Use Twig_SimpleFunction instead."